### PR TITLE
Add case insensitive matching of extensions

### DIFF
--- a/app/src/main/java/io/github/robertaguilera712/cisojr4droid/utils/FileUtils.java
+++ b/app/src/main/java/io/github/robertaguilera712/cisojr4droid/utils/FileUtils.java
@@ -95,7 +95,7 @@ public class FileUtils implements DefaultLifecycleObserver {
                         final String fileName = file.getName();
                         final String fileExtension = fileName.substring(fileName.lastIndexOf("."));
                         final String fileMimeType = file.getType();
-                        if (inputMimeType.equals(fileMimeType) && inputFileExtension.equals(fileExtension)) {
+                        if (inputMimeType.equals(fileMimeType) && inputFileExtension.equals(fileExtension.toLowerCase())) {
                             final Uri inputUri = file.getUri();
                             final String inputFilename = file.getName();
                             final String outputFilename = inputFilename.replaceFirst(inputFileExtension + "$", outputFileExtension);


### PR DESCRIPTION
Runs the comparison against the lowercase form of the extension so that all files show up regardless if they're CSO, cso, ISO, iso, or IsO.